### PR TITLE
fix ordering

### DIFF
--- a/_includes/collect/info-card.html
+++ b/_includes/collect/info-card.html
@@ -44,7 +44,7 @@
             <li class="usa-collection__meta-item">
                 <b>Content:</b>
                 <ul class="unstyled-list">
-                    {% assign psubset=pagesubset %}
+                    {% assign psubset=pagesubset | sort: "ordered" %}
                     {% assign largersubset=mypagesubset %}
                     {% for sets in psubset %}
                         {% include collect/list.html set=sets mysubset=largersubset class="usa-collection__meta-item" aclass="text-bold text-underline" %}

--- a/_includes/collect/list.html
+++ b/_includes/collect/list.html
@@ -21,7 +21,7 @@
 {% if tsets.org %}
     {% unless pssize == 0 %}
 <ul class="{%- unless sort_list %}icon-ul{%- endunless %}">
-    {% assign _usubset = pagesubset %}
+    {% assign _usubset = pagesubset | sort: "ordered" %}
     {% unless include.loop=="looped" %}{% assign smallersubset=mypagesubset %}{% endunless %}
     {% for _set in _usubset %}
         {% include collect/list.html set=_set mysubset=smallersubset class="" loop="looped" %}


### PR DESCRIPTION
Fix ordering in workbook filters page.
This will allow for cleaning up the URLs to make navigation easier.